### PR TITLE
import a basic docker file based on centos 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+
+sudo: false
+
+services:
+  - docker
+
+script: docker build . -f Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+#
+# This is the image that controls the standard build environment for releasing MetalKube components.
+#
+# The standard name for this image is metalkube/metalkube-base-image
+#
+FROM        centos:7
+
+ENV VERSION=1.11.5 \
+    GOCACHE=/go/.cache \
+    GOARM=5 \
+    GOPATH=/go \
+    GOROOT=/usr/local/go
+ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+
+COPY cbs-paas7-openshift-multiarch-el7-build.repo /etc/yum.repos.d/
+RUN yum install -y epel-release && \
+    rpm -V epel-release && \
+    INSTALL_PKGS="bc bind-utils bsdtar ceph-common createrepo device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc git glibc-static glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel libvirt-devel lsof make mercurial nmap-ncat openssl protobuf-compiler rsync socat systemd-devel sysvinit-tools tar tito tree util-linux wget which xfsprogs zip goversioninfo" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    touch /os-build-image && \
+    git config --system user.name metalkube && \
+    git config --system user.email metalkube-dev@groups.google.com
+
+RUN yum install -y golang && \
+    yum clean all && \
+    curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
+    go get golang.org/x/tools/cmd/cover \
+        github.com/Masterminds/glide \
+        golang.org/x/tools/cmd/goimports \
+        github.com/tools/godep \
+        golang.org/x/lint/golint \
+        github.com/openshift/imagebuilder/cmd/imagebuilder && \
+    mv $GOPATH/bin/* /usr/bin/ && \
+    rm -rf $GOPATH/* $GOPATH/.cache && \
+    mkdir $GOPATH/bin && \
+    ln -s /usr/bin/imagebuilder $GOPATH/bin/imagebuilder && \
+    ln -s /usr/bin/goimports $GOPATH/bin/goimports
+    # TODO: symlink for backwards compatibility with hack/build-images.sh only, remove
+
+RUN chmod g+xw -R $GOPATH && \
+    chmod g+xw -R $(go env GOROOT)
+
+LABEL io.k8s.display-name="MetalKube Base Image" \
+      io.k8s.description="This is the base image for the MetalKube components."

--- a/cbs-paas7-openshift-multiarch-el7-build.repo
+++ b/cbs-paas7-openshift-multiarch-el7-build.repo
@@ -1,0 +1,8 @@
+[cbs-paas7-openshift-multiarch-el7-build]
+name = CBS OpenShift MultiArch Build
+baseurl = http://cbs.centos.org/kojifiles/repos/paas7-openshift-multiarch-el7-build/latest/$basearch
+enabled = 1
+gpgcheck = 0
+sslverify = 0
+skip_if_unavailable = 1
+includepkgs = golang* protobuf* goversioninfo* openvswitch*


### PR DESCRIPTION
This file is based on the openshift golang 1.11 image defined in
https://github.com/openshift/release/blob/master/projects/origin-release/golang-1.11/Dockerfile